### PR TITLE
correct association syntax

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
 class Tag < ActiveRecord::Base
   has_many :post_tags
-  has_many :posts, through:post_tags
+  has_many :posts, through: :post_tags
 end


### PR DESCRIPTION
was --> has_many :posts, through:post_tags
should've been --> has_many :posts, through: :post_tags

good catch @taylor-d 
