### PR TITLE
remove get routes for cached votes. already in the post model

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,6 @@ scope defaults: {format: 'json'} do
     member do
       put '/like', to: 'posts#upvote'
       put '/dislike', to: 'posts#downvote'
-      get '/:cached_votes_total', to: 'posts#show'
-      get '/:cached_votes_up', to: 'posts#show'
-      get '/:cached_votes_down', to: 'posts#show'
     end
   end
 


### PR DESCRIPTION
removed get routes for cached votes. already in the post model.
cc: @taylor-d 
