### PR TITLE
remove trailing dots in Find All Tags JSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ Example response:
       "id": 6,
       "name": "android",
       "taggings_count": 0
-    }...
+    }
   ]
 }
 ```


### PR DESCRIPTION
removed trailing dots in Find All Tags JSON example.
cc: @taylor-d
